### PR TITLE
Generate valid DMK files when built on 64-bit architectures.

### DIFF
--- a/cwpci.c
+++ b/cwpci.c
@@ -24,14 +24,12 @@
 #define DEBUG_PCI(stmt)
 
 #include <stdio.h>
+#include <stdint.h>
 #include "cwpci.h"
 
 #if __DJGPP__
 #include <dpmi.h>
 #include <string.h>
-
-typedef unsigned short uint16;
-typedef unsigned long uint32;
 
 /* Translate PCI BIOS error code to string.
  * See http://www.delorie.com/djgpp/doc/rbinter/it/29/7.html
@@ -142,7 +140,7 @@ pci_find(int vendorID, int deviceID, int index,
  */
 int
 pci_read_config_dword(int bus, int device, int func,
-		      int reg, uint32 *value)
+		      int reg, uint32_t *value)
 {
   __dpmi_regs r;
 
@@ -180,7 +178,7 @@ pci_find_catweasel(int index, int *cw_mk)
 {
   int i = 0, j = 0, res;
   int bus, device, func, mk = 0;
-  uint32 subsysID, baseAddr;
+  uint32_t subsysID, baseAddr;
 
   if (pci_install_check() != 0) return -1;
 

--- a/cwpci.c
+++ b/cwpci.c
@@ -271,11 +271,15 @@ pci_find_catweasel(int index, int *cw_mk)
       for (i = 0; i < 6; i++) {
 	unsigned flg = pci_read_long(pd, PCI_BASE_ADDRESS_0 + 4 * i);
 	if (flg != 0xffffffff && (flg & PCI_BASE_ADDRESS_SPACE_IO)) {
+	  u16 sval;
+	  sval = pci_read_word(pd, PCI_COMMAND);
+	  sval |= PCI_COMMAND_MEMORY | PCI_COMMAND_IO;
+	  pci_write_word(pd, PCI_COMMAND, sval);
 	  *cw_mk = mk;
 	  return pd->base_addr[i] & PCI_ADDR_IO_MASK;
 	}
 	DEBUG_PCI( printf("baseAddr %d 0x%llx not I/O space\n",
-			  i, pd->base_addr[i]); )
+			  i, (long long)pd->base_addr[i]); )
       }
     }
 

--- a/dmk.h
+++ b/dmk.h
@@ -1,3 +1,5 @@
+#include <stdint.h>
+
 /* Some constants for DMK format */
 #define DMK_WRITEPROT     0
 #define DMK_NTRACKS       1
@@ -47,10 +49,10 @@
 #define DMK_IDAMP_BITS    0x3fff
 
 typedef struct {
-  unsigned char writeprot;
-  unsigned char ntracks;
-  unsigned short tracklen;
-  unsigned char options;
-  unsigned char padding[7];
-  unsigned long mbz;
+  uint8_t	writeprot;
+  uint8_t	ntracks;
+  uint16_t	tracklen;
+  uint8_t	options;
+  uint8_t	padding[7];
+  uint32_t	mbz;
 } dmk_header_t;

--- a/dmk2cw.c
+++ b/dmk2cw.c
@@ -148,7 +148,7 @@ double
 cw_measure_rpm(catweasel_drive *d)
 {
   struct timeval t1, t2;
-  long usec;
+  long long usec;
 
   catweasel_await_index(d);
   gettimeofday(&t1, NULL);


### PR DESCRIPTION
When compiling on x86_64, the existing code does not properly generate valid DMK files due to incorrect size of the DMK header (dmk_header_t).  I've addressed that and other 32-bit vs. 64-bit issues in the code that I found as well.  However, I'm not sure I caught everything, but I think this is a good start.