### PR TITLE
Compile the crc test app

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@ dmk2cw
 dmk2jv3
 jv2dmk
 cwtsthst
+crc

--- a/Makefile
+++ b/Makefile
@@ -34,7 +34,7 @@ else
   PCILIB = -lpci -lz
 endif
 
-CFLAGS = -O3 -g -Wall
+CFLAGS = -O3 -g -Wall -std=gnu99
 
 version := $(shell grep VERSION version.h | sed -re 's/^.*"([^"]+)".*$$/\1/')
 
@@ -71,7 +71,7 @@ endif
 BUILD_TARGETS   = firmware.h $(TXT) $(EXE)
 RELEASE_TARGETS = COPYING README ChangeLog $(TXT) $(EXE)
 
-clean = $(EXE) $(TAR_TARGETS) *.$O *~
+clean = $(EXE) $(TAR_TARGETS) crc$E *.$O *~
 veryclean = $(clean) $(TXT) firmware.h *.exe *.obj *.o *.tar.gz
 
 all: progs manpages
@@ -98,6 +98,9 @@ jv2dmk$E: jv2dmk.c crc.c dmk.h jv3.h
 
 cwtsthst$E: testhist.c catweasl.$O cwpci.$O cwfloppy.h
 	$(CC) $(CFLAGS) -o $@ $< catweasl.$O cwpci.$O $(PCILIB) -lm
+
+crc$E: crc.c
+	$(CC) $(CFLAGS) -DTEST -o $@ $<
 
 firmware.h: $(FIRMWARE)
 	(echo 'unsigned char firmware[] = { ' ;\

--- a/crc.c
+++ b/crc.c
@@ -60,7 +60,7 @@ unsigned short CALC_CRC1a(unsigned short crc, unsigned char byte)
 
 /* Recompute the CRC with len bytes appended. */
 unsigned short calc_crc(unsigned short crc,
-			unsigned char const *buf, int len) 
+			unsigned char const *buf, int len)
 {
   while (len--) {
     crc = calc_crc1(crc, *buf++);
@@ -70,10 +70,17 @@ unsigned short calc_crc(unsigned short crc,
 
 #if TEST
 #include <stdio.h>
+#include <stdlib.h>
+/*
+ * crc app.  Usage: crc [initial_value].  If the initial_value is
+ * omitted, it defaults to 0xffff.  crc reads hex bytes, optionally
+ * separated by whitespace, from stdin until end of file.  It computes
+ * the crc of the byte sequence and outputs it in hex on stdout.
+ */
 int
 main(int argc, char **argv)
 {
-  char buf[2048];
+  unsigned char buf[2048];
   int count, c, res;
   unsigned short preset;
 


### PR DESCRIPTION
I still think of the crc app as just a developer tool, so I didn't add
it to "progs"; you have to do "make crc" to compile it.  I did add
some minimal documentation in a comment.

I also updated crc.c and the Makefile so that I can compile the
package without warnings on both Ubuntu 20.04 (gcc version 9.3.0) and
Ubuntu 8.04 (gcc version 4.2.4) without warnings.  The crc.c change
was needed for gcc 9.3.0, and the Makefile change (-std=gnu99) was
needed for 4.2.4, which otherwise enforces an even older C standard.