### PR TITLE
Add format quirk support to cw2dmk.

### DIFF
--- a/cw2dmk.c
+++ b/cw2dmk.c
@@ -819,7 +819,7 @@ process_bit(int bit)
   accum = (accum << 1) + bit;
   taccum = (taccum << 1) + bit;
   bits++;
-  if (mark_after > 0) mark_after--;
+  if (mark_after >= 0) mark_after--;
   if (write_splice > 0) write_splice--;
 
   /*

--- a/cw2dmk.c
+++ b/cw2dmk.c
@@ -1190,6 +1190,11 @@ process_bit(int bit)
     } else {
       msg(OUT_ERRORS, "[bad extra CRC] ");
       errcount++;
+      if (accum_sectors) {
+	if (dmk_idam_p[-1] & DMK_EXTRA_FLAG)
+	  errcount--;
+	dmk_idam_p[-1] |= DMK_EXTRA_FLAG;
+      }
     }
     msg(OUT_HEX, "\n");
     ebyte = -1;

--- a/cw2dmk.man
+++ b/cw2dmk.man
@@ -435,31 +435,44 @@ option is not useful for reading the back of a flippy disk; see the
 Enable support for various format quirks.  To enable multiple quirks,
 add the values together.  The value can be given either in hex with a
 0x prefix or in decimal.  For example, -q17 enables quirks 1 and 16.
+So far these quirks have been seen only on UDOS disks; see Limitations.
 .RS
 .TP
-0x01 (1)
+0x01 (1) QUIRK_ID_CRC
 The ID CRCs are calculated without including the a1 a1 a1 premark bytes.
+If this quirk is needed but not enabled (or enabled when not needed!),
+cw2dmk will detect an ID CRC error on every sector.
 .TP
-0x02 (2)
+0x02 (2) QUIRK_DATA_CRC
 The data CRCs are calculated without including the a1 a1 a1 premark bytes.
+If this quirk is needed but not enabled (or enabled when not needed!),
+cw2dmk will detect a data CRC error on every sector.
 .TP
-0x04 (4)
-In the a1 a1 a1 premark, possibly only the first two bytes have a missing clock.
+0x04 (4) QUIRK_PREMARK
+In the a1 a1 a1 premark, possibly only the first two bytes have a
+missing clock.  If this quirk is needed but not enabled, cw2dmk will
+fail to detect some ID address marks and/or data address marks.  If
+this quirk is enabled when not needed, there is a very small chance it
+could lead to a problem where an address mark is falsely detected and
+cw2dmk reports it as an error.
 .TP
-0x08 (8)
-Immediately following the CRC of each data sector, there are an
-unspecified number of extra, meaningful data bytes.  This quirk
-suppresses resynchronizing the decoder when what appears to be an
-unsynchronized MFM 4e 4e or 00 00 sequence appears in the gap
-following a data sector, as doing that could damage the extra bytes.
+0x08 (8) QUIRK_EXTRA
+Immediately following the CRC of each data sector, there are some
+extra, meaningful data bytes.  This quirk prevents the extra
+bytes from being damaged, by forbidding the decoder from resynchronizing
+to apparent MFM 4e 4e or 00 00 byte sequences as expected in the
+gap.  As a result, the decoder generally will not resynchronize until
+the a1 a1 a1 sequence preceding the next ID address mark, so the gap
+bytes preceding it that should be 4e 4e... 00 00... are likely to be
+decoded incorrectly.
 .TP
-0x10 (16)
+0x10 (16) QUIRK_EXTRA_CRC
 Immediately following the CRC of each data sector, there are four
-extra, meaningful data bytes followed by two extra CRC bytes that
+extra, meaningful data bytes, followed by two extra CRC bytes that
 cover the four extra data bytes.  The extra CRC is checked and the
-track read retried if it is invalid.  Unlike with quirk 0x08, the
-decoder is allowed to resynchronize to MFM 4e 4e or 00 00 sequences in
-the gap after the extra CRC.
+track read is retried if the CRC is invalid.  Unlike with quirk 0x08,
+the decoder is allowed to resynchronize to apparent MFM 4e 4e or 00 00
+byte sequences following the extra CRC.
 .RE
 .P
 The next few options modify individual
@@ -553,6 +566,25 @@ a standard floppy drive, give the -h0 option to ignore the index hole
 position, the -k1 or -k2 option as needed to specify the kind of drive
 and media in use, and the -l 0x1A40 option to increase the DMK track
 length.  
+
+Various East German computers that used floppy disk controllers built
+from discrete logic and that ran variants of the UDOS operating system
+produce disks with nonstandard formats.  See
+https://www.robotrontechnik.de/html/software/udos.htm.  To read these
+disks, use cw2dmk's quirk support (-q option).  UDOS disks generally
+have four extra bytes of meaningful data following the data CRC,
+sometimes followed by a two-byte CRC covering only the extra bytes, so
+they require QUIRK_EXTRA or QUIRK_EXTRA_CRC to ensure the extra bytes
+are read correctly.  Some of the variants also have other nonstandard
+features that require QUIRK_PREMARK and/or QUIRK_ID_CRC.  The
+following information is based on a small sample of the disks, and
+does not cover all UDOS variants: UDOS PRG v4 disks need -q0x0d
+(QUIRK_ID_CRC, QUIRK_PREMARK, QUIRK_EXTRA).  UDOS 1526 v4 needs only
+-q0x08 (QUIRK_EXTRA).  UDOS 1526 v5 needs -q0x0c (QUIRK_PREMARK,
+QUIRK_EXTRA).  If you have a version of UDOS where the extra CRC is
+always present, it is preferable to use QUIRK_EXTRA_CRC instead of
+QUIRK_EXTRA, so that cw2dmk will check the extra CRC and retry if it
+shows an error.
 .SH Diagnostics
 .TP 
 .B cw2dmk: Must be setuid to root or be run as root

--- a/cw2dmk.man
+++ b/cw2dmk.man
@@ -93,7 +93,7 @@ Print "(-N)" or "(+N)"
 where the decoder dropped or duplicated N clock/data bits in an attempt to
 resynchronize itself with the data bit and byte boundaries.
 Print a "?" before any byte where a
-clock was unexpectedly missing or unexpectedly present even after the
+clock was missing or unexpectedly present even after the
 resynchronization heuristics were applied.
 .TP
 6
@@ -430,6 +430,37 @@ disk twice, once with -s1 -r0 and once with -s1 -r1, gives you a
 separate 1-sided DMK image of each side of the disk.  (Note: this
 option is not useful for reading the back of a flippy disk; see the
 -h0 option.)
+.TP
+.B \-q \fIquirk\fP
+Enable support for various format quirks.  To enable multiple quirks,
+add the values together.  The value can be given either in hex with a
+0x prefix or in decimal.  For example, -q17 enables quirks 1 and 16.
+.RS
+.TP
+0x01 (1)
+The ID CRCs are calculated without including the a1 a1 a1 premark bytes.
+.TP
+0x02 (2)
+The data CRCs are calculated without including the a1 a1 a1 premark bytes.
+.TP
+0x04 (4)
+In the a1 a1 a1 premark, possibly only the first two bytes have a missing clock.
+.TP
+0x08 (8)
+Immediately following the CRC of each data sector, there are an
+unspecified number of extra, meaningful data bytes.  This quirk
+suppresses resynchronizing the decoder when what appears to be an
+unsynchronized MFM 4e 4e or 00 00 sequence appears in the gap
+following a data sector, as doing that could damage the extra bytes.
+.TP
+0x10 (16)
+Immediately following the CRC of each data sector, there are four
+extra, meaningful data bytes followed by two extra CRC bytes that
+cover the four extra data bytes.  The extra CRC is checked and the
+track read retried if it is invalid.  Unlike with quirk 0x08, the
+decoder is allowed to resynchronize to MFM 4e 4e or 00 00 sequences in
+the gap after the extra CRC.
+.RE
 .P
 The next few options modify individual
 parameters that are normally set correctly by the -k option (or by

--- a/decoder.txt
+++ b/decoder.txt
@@ -244,28 +244,35 @@ ID address mark is 00a1a1a1fe, a normal DAM is 00a1a1a1fb, and a
 deleted DAM is 00a1a1a1f8.  Many other marks would be possible with
 this scheme, but I don't know of any others being used.
 
-Premark 0xc2 with missing clock (indicated as "o"):
+Premark c2 c2 with missing clock (indicated as "o"):
 
         ------c ------2 ------c ------2
 data:   1 1 0 0 0 0 1 0 1 1 0 0 0 0 1 0
 clock: 0 0 0 1 o 1 0 0 0 0 0 1 o 1 0 0 
        ---5---2---2---4---5---2---2---4
 
-Premark 0xa1 with missing clock (indicated as "o"):
+Premark a1 a1 with missing clock (indicated as "o"):
 
         ------a ------1 ------a ------1
 data:   1 0 1 0 0 0 0 1 1 0 1 0 0 0 0 1
 clock: 0 0 0 0 1 o 1 0 0 0 0 0 1 o 1 0
        ---4---4---8---9---4---4---8---9
 
-Ordinary data 0x4e4e (preceded by a 0 data bit, say from another 0x4e):
+Premark a1 a1 with missing clock only in first copy (indicated as "o"):
+
+        ------a ------1 ------a ------1
+data:   1 0 1 0 0 0 0 1 1 0 1 0 0 0 0 1
+clock: 0 0 0 0 1 o 1 0 0 0 0 0 1 1 1 0
+       ---4---4---8---9---4---4---a---9
+
+Ordinary data 4e 4e (preceded by a 0 data bit, say from another 4e):
 
         ------4 ------e ------4 ------e
 data: 0 0 1 0 0 1 1 1 0 0 1 0 0 1 1 1 0
 clock: 1 0 0 1 0 0 0 0 1 0 0 1 0 0 0 0
        ---9---2---5---4---9---2---5---4
 
-Ordinary data 0x4e read in each possible wrong alignment:
+Ordinary data 4e 4e read in each possible bit alignment (0 = correct):
 
 data:   0 1 0 0 1 1 1 0 0 1 0 0 1 1 1 0
 0)      ------4 ------e
@@ -303,11 +310,11 @@ clock: 1 0 0 1 0 0 0 0 1 0 0 1 0 0 0 0
 Backward MFM
 ------------
 
-A backward 0xa1a1a1 premark preceded by a 00 byte looks like a forward
-0xc2c2 premark followed by an 0x80.  This sequence is not used as a
+A backward a1 a1 a1 premark preceded by a 00 byte looks like a forward
+c2 c2 c2 premark followed by an 80.  This sequence is not used as a
 normal mark, so the decoder is able to recognize it.  This would also
 work for premarks consisting of only two 0xa1's, as long as the next
-byte had the high bit set; for example, 0x00a1a1fb.
+byte has the high bit set; for example, 0x00a1a1fb.
 
           1-----< a-----< 1-----< a-----< 0-----< 0-----<
 data:   1 1 0 0 0 0 1 0 1 1 0 0 0 0 1 0 1 0 0 0 0 0 0 0 0


### PR DESCRIPTION
This change was motivated by attempting to read various flavors of
UDOS disk from Rüdiger Kurth more accurately.

UDOS PRG v4 reads best with -q0x0d (QUIRK_ID_CRC, QUIRK_PREMARK,
QUIRK_EXTRA).  QUIRK_EXTRA_CRC does not work on the sample disk I have
because the extra CRCs are correct only for sectors that have been
formatted but not written to yet.  Sectors that have been written to
seem to have only 4 extra bytes before the write splice, no CRC.

UDOS 1526 v4 reads best with -q0x08 (QUIRK_EXTRA).  Here there are no
extra bytes on sectors that have been formatted but not written to yet
-- the bytes after the data CRC are 4e 4e 4e 4e 4e 4e.  Sectors that
have been written to seem to have only 4 extra bytes, no CRC.

UDOS 1526 v5 reads best with -q0x0c (QUIRK_PREMARK,
QUIRK_EXTRA). Sectors that have been written to seem to have only 4
extra bytes (often 4e 4e 4e 4e) before the write splice, no CRC.

I also have a DMK image that Rüdiger sent (no physical disk) where all
the extra byte CRCs are correct.  This one would have read best with
-q0x10 (QUIRK_EXTRA_CRC), which checks the extra CRC and retries if
it's incorrect.  I am not sure what UDOS variant it is from.