### PR TITLE
Quirk iam

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,4 +1,6 @@
-* Various minor cleanup of code and the cw2dmk usage message.
+* Add QUIRK_IAM to -q option in cw2dmk.
+
+* Various minor cleanup of code and the cw2dmk	usage message.
 
 * Add -X (force retry) feature to cw2dmk.  In the future this may be
   changed to take an argument giving the number of retries to force,

--- a/cw2dmk.man
+++ b/cw2dmk.man
@@ -499,6 +499,11 @@ Each sector has 4 more data bytes preceding the CRC than its size code
 indicates.  For example, if the size code indicates 128 bytes, there
 are actually 132 data bytes, followed by a standard 2-byte CRC that
 covers the data address mark and all 132 data bytes.
+.TP
+0x40 (64) QUIRK_IAM
+A standard index address mark (IAM) in FM is the data value 0xfc with
+a 0xd7 clock pattern. If this quirk is specified, cw2dmk recognizes
+0xfc with either a 0xd7 or 0xc7 clock pattern as an IAM.
 .RE
 .P
 The next few options modify individual
@@ -606,15 +611,15 @@ ensure the bytes are read correctly and their CRC is checked), or
 precede the data CRC and are included in the data CRC's coverage (use
 QUIRK_EXTRA_DATA to avoid a data CRC error on every sector).  Some of
 the variants also have other nonstandard features that require
-QUIRK_PREMARK and/or QUIRK_ID_CRC.
+QUIRK_PREMARK, QUIRK_ID_CRC, and/or QUIRK_IAM.
 
 The following information is based on a small sample of UDOS disks.
 It does not cover all UDOS variants and may not be fully accurate, so
 try other combinations of quirks if these don't work: UDOS PRG v4
 disks need -q0x0d (QUIRK_ID_CRC, QUIRK_PREMARK, QUIRK_EXTRA).  UDOS
 1526 v4 needs only -q0x08 (QUIRK_EXTRA).  UDOS 1526 v5 needs -q0x0c
-(QUIRK_PREMARK, QUIRK_EXTRA).  CZ-SDOS needs -q0x20
-(QUIRK_EXTRA_DATA).  Note: If you have a version of UDOS where
+(QUIRK_PREMARK, QUIRK_EXTRA).  CZ-SDOS needs -q0x60
+(QUIRK_EXTRA_DATA, QUIRK_IAM).  Note: If you have a version of UDOS where
 QUIRK_EXTRA_CRC works, it is preferable to use it instead of
 QUIRK_EXTRA, so that cw2dmk will check the extra CRC and retry if it
 shows an error.

--- a/decoder.txt
+++ b/decoder.txt
@@ -89,7 +89,7 @@ Index address mark
 
         ------f ------c
 data:   1 1 1 1 1 1 0 0
-clock: 1 1 0 1 0 1 1 1 
+clock: 1 1 0 1 0 1 1 1
        ---f---7---7---a
 
 At the MFM double data rate, preceded by one extra 0 bit, this looks
@@ -107,7 +107,7 @@ ID address mark
 
         ------f ------e
 data:   1 1 1 1 1 1 1 0
-clock: 1 1 0 0 0 1 1 1 
+clock: 1 1 0 0 0 1 1 1
        ---f---5---7---e
 
              ------------f   ------------e
@@ -122,7 +122,7 @@ Standard deleted data address mark
 
         ------f ------8
 data:   1 1 1 1 1 0 0 0
-clock: 1 1 0 0 0 1 1 1 
+clock: 1 1 0 0 0 1 1 1
        ---f---5---5---a
 
              ------------f   ------------8
@@ -138,7 +138,7 @@ Also used as RX02 deleted data address mark (see below)
 
         ------f ------9
 data:   1 1 1 1 1 0 0 1
-clock: 1 1 0 0 0 1 1 1 
+clock: 1 1 0 0 0 1 1 1
        ---f---5---5---b
 
              ------------f   ------------9
@@ -153,7 +153,7 @@ Nonstandard data address mark available with WD1771 FDCs
 
         ------f ------a
 data:   1 1 1 1 1 0 1 0
-clock: 1 1 0 0 0 1 1 1 
+clock: 1 1 0 0 0 1 1 1
        ---f---5---5---e
 
              ------------f   ------------a
@@ -168,7 +168,7 @@ Standard normal data address mark
 
         ------f ------b
 data:   1 1 1 1 1 0 1 1
-clock: 1 1 0 0 0 1 1 1 
+clock: 1 1 0 0 0 1 1 1
        ---f---5---5---f
 
              ------------f   ------------b
@@ -183,15 +183,37 @@ RX02 normal data address mark (see below)
 
         ------f ------d
 data:   1 1 1 1 1 1 0 1
-clock: 1 1 0 0 0 1 1 1 
+clock: 1 1 0 0 0 1 1 1
        ---f---5---7---b
 
-             ------------f   ------------d         
+             ------------f   ------------d
 data:    0   1   1   1   1   1   1   0   1
 clock: 1   1   1   0   0   0   1   1   1
 space:  0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0
        ---8---a---a---2---2---2---a---8---a
 
+
+Quirky FM IAM
+-------------
+
+At least one CZ-SDOS disk has been seen that sometimes uses 0xfc with
+a 0xc7 clock pattern as an IAM instead of the standard 0xfc with 0xd7
+clock pattern.  Strangely, the disk actually has a mix of both.
+Turning on QUIRK_IAM recognizes both as IAMs.
+
+Quirky index address mark
+0xfc with 0xc7 clock pattern:
+
+        ------f ------c
+data:   1 1 1 1 1 1 0 0
+clock: 1 1 0 0 0 1 1 1
+       ---f---5---7---a
+
+             ------------f   ------------c
+data:    0   1   1   1   1   1   1   0   0
+clock: 1   1   1   0   0   0   1   1   1
+space:  0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0
+       ---8---a---a---2---2---2---a---8---8
 
 Backward FM
 -----------
@@ -199,13 +221,18 @@ Backward FM
 Reading any of the data address marks (0xf8, 0xf9, 0xfa, 0xfb, or 0xfd
 with 0xc7 clock) backward, starting from just before the three data
 bits that distinguish them from each other and continuing into the
-preceding 00 byte, happens to yield a unique pattern that is also
-missing clock bits but does not match any of the FM address marks read
-forward.  Like forward FM address marks, the pattern is legal within
-MFM data, so the decoder doesn't look for it within MFM ID or sector
-data.
+preceding 00 byte, happens to yield a pattern that is also missing
+clock bits but does not match any of the FM address marks read forward
+except the quirky FM IAM.
 
-That is:
+Like forward FM address marks, the pattern is legal within MFM data,
+so the decoder doesn't look for it within MFM ID or sector data.  To
+avoid firing on the quirky FM IAM, the decoder doesn't look for a
+backward FM IAM if a mark has already been predetected; this works
+because the quriky IAM pattern matches earlier in the data stream than
+the backward IAM pattern.  To avoid firing so often on write splices
+and other noise, the detector also doesn't look for a backward FM IAM
+if any good sectors have already been seen on the track.
 
         X-----< f-----<
 data:   X X X 1 1 1 1 1 0 0 0 0
@@ -248,7 +275,7 @@ Premark c2 c2 with missing clock (indicated as "o"):
 
         ------c ------2 ------c ------2
 data:   1 1 0 0 0 0 1 0 1 1 0 0 0 0 1 0
-clock: 0 0 0 1 o 1 0 0 0 0 0 1 o 1 0 0 
+clock: 0 0 0 1 o 1 0 0 0 0 0 1 o 1 0 0
        ---5---2---2---4---5---2---2---4
 
 Premark a1 a1 with missing clock (indicated as "o"):


### PR DESCRIPTION
Here's another change motivated by weirdness on one of Rüdiger's disks. This disk seems to have been written by the original OS without regard for the index hole location, so some sectors are split across the index hole in such a way that a Catweasel hole to hole read can't successfully decode the sector, because some of it is missing both from the beginning and the end.

With this change that fixes IAM detection, Rüdiger would be able to reread the disk with -h0 and -i96 or so and get a good read with all the tracks lined up starting at the IAM.  (Without the change, -h0 would still work and would get all the sectors, but -i couldn't align them because the IAM doesn't get detected on many of the tracks.)
