### PR TITLE
Allow -h0 in replay mode and document the need for it

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -71,7 +71,7 @@ endif
 BUILD_TARGETS   = firmware.h $(TXT) $(EXE)
 RELEASE_TARGETS = COPYING README ChangeLog $(TXT) $(EXE)
 
-clean = $(EXE) $(TAR_TARGETS) crc$E *.$O *~
+clean = $(EXE) $(TAR_TARGETS) crc$E parselog$E *.$O *~
 veryclean = $(clean) $(TXT) firmware.h *.exe *.obj *.o *.tar.gz
 
 all: progs manpages

--- a/cw2dmk.c
+++ b/cw2dmk.c
@@ -1886,10 +1886,10 @@ main(int argc, char** argv)
       exit(1);
     }
     if (steps != -1 || menu_intr_enabled != 0 || menu_err_enabled != 0 ||
-        drive != -1 || port != 0 || alternate != 0 || hole != 1 ||
+        drive != -1 || port != 0 || alternate != 0 ||
         reverse != 0 || x_given != 0) {
       fprintf(stderr, "cw2dmk: Replay (-R) mode does not support "
-              "options -m, -M, -d, -p, -a, -h, -r, or -x\n");
+              "options -m, -M, -d, -p, -a, -r, or -x\n");
       exit(1);
     }
     steps = 1;

--- a/cw2dmk.c
+++ b/cw2dmk.c
@@ -1275,8 +1275,10 @@ process_sample(int sample)
 
   msg(OUT_SAMPLES, "%c ", "--sml"[len]);
 
-  process_bit(1);
-  while (--len) process_bit(0);
+  if (!dmk_full) {
+    process_bit(1);
+    while (--len) process_bit(0);
+  }
 }
 
 
@@ -2235,7 +2237,7 @@ main(int argc, char** argv)
 	int b = 0;
 	int oldb = 0;
 	index_edge = 0;
-	while (!dmk_full) {
+	while (!dmk_full || out_level >= OUT_SAMPLES) {
           if (replay) {
             b = parse_sample(replay_file);
           } else {

--- a/cw2dmk.man
+++ b/cw2dmk.man
@@ -116,15 +116,16 @@ appending .log instead.  If you give the -u option with a one-digit -v
 option, the same output is logged to the file and to the screen.
 .TP
 .B \-R \fIlogfile\fP
-Replay a level 7 verbosity logfile instead of reading a new disk
-from the Catweasel.  This option can be useful to retry decoding
-a disk using different command line options, without physically
-rereading the disk.  First capture a logfile at verbosity level 7
-using the -v and -u options.  Then run cw2dmk as many times
-as desired, using the -R option to replay the logfile, together
-with other command line options as desired.  The -k option is
-always required with -R, while the -m, -M, -d, -p, -a, -h,
--r, and -x options are not allowed.
+Replay a level 7 verbosity logfile instead of reading a new disk from
+the Catweasel.  This option can be useful to retry decoding a disk
+using different command line options, without physically rereading the
+disk.  First capture a logfile at verbosity level 7 using the -v and
+-u options.  Then run cw2dmk as many times as desired, using the -R
+option to replay the logfile, together with other command line options
+as desired.  The -k option is always required with -R, and the -h0
+option generally should be used if the original capture was performed
+with -h0, while the -m, -M, -d, -p, -a, -r, and -x options are not
+allowed.
 .TP
 .B \-M {i,e,d}\fP
 Controls interactive menu mode.  Option-argument "i" enables
@@ -351,13 +352,19 @@ option before being added to the next interval.
 .TP
 .B \-h \fIhole\fP
 If hole is 1 (the default), cw2dmk uses the disk's index hole to
-determine where each track starts.  If hole is set to 0, cw2dmk reads
-disks without using the index hole.  With -h0, the tracks in the DMK
-file will not start with the same sector as on the original disk (but
-the -i option can sometimes fix this; see below).  Note that if the
-disk actually has no index hole, cw2dmk cannot autodetect the
-drive/media type, so you must also give the -k option to specify the
-type.
+determine where each track starts.
+
+If hole is set to 0, cw2dmk reads disks without using the index hole.
+With -h0, the tracks in the DMK file will not start with the same
+sector as on the original disk.  Instead, each track will start 48
+bytes before the ID address mark (IDAM) of the first sector that
+cw2dmk happens to read on the media.  Alternatively, if the tracks
+have an index address mark (IAM), the -i option (see below) can be
+used to position the track start relative to the IAM.
+
+Note that if a disk actually has no index hole, cw2dmk cannot
+autodetect the drive/media type, so you must give the -k option
+to specify the type as well as giving -h0.
 
 One case where the -h0 option is useful is if the last sector on a
 track wraps around far past the index hole and is partially cut off by


### PR DESCRIPTION
Reading in -h0 has the extra feature (previously not documented in the
man page) of starting the DMK track 48 bytes prior to the first IDAM
decoded from the track.  This feature exists because otherwise there
would often be so much garbage (i.e., a partial sector) at the front
of the DMK track that the DMK track buffer would fill up before there
is room for all the valid sectors.

This feature is needed when replaying an -h0 capture too, so this
change allows that and recommends it in the man page.

Future: It might be a good idea to read the original options that were
used in making the capture from the log file, and use at least some of
them as defaults for the replay.  -k and -h are prime candidates.