### PR TITLE
Fix bug in logging all Catweasel samples when at level 7

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,9 @@
+* Add -T step_time,settling_time feature to both cw2dmk and dmk2cw.
+
+* Log all Catweasel samples when at verbosity level 7, instead of
+  stopping when the DMK buffer is full.  (This change was actually
+  made in 4.9.0, but it had a bug that is now fixed.)
+
 4.9.0 -- Sat Apr 30 17:07:57 UTC 2022 -- Tim Mann, Quentin Barnes
 
 * Catch errors when writing to files.   Report and exit when errors

--- a/catweasl.c
+++ b/catweasl.c
@@ -158,7 +158,7 @@ unsigned char Mk3StatusBit[] = {
 };
 
 /* Control bit position names (write CatControl) */
-enum CatControlBit { 
+enum CatControlBit {
     CatStep, CatSideSelect, CatMotor0, CatDirection,
     CatSelect0, CatSelect1, CatMotor1, CatDensityOut
 };
@@ -326,9 +326,8 @@ static void
 CWTriggerStep(catweasel_contr *c)
 {
     CWSetCReg(c, CBIT(c, CatStep), 0);
-    catweasel_usleep(c->step_us/2);
     CWSetCReg(c, 0, CBIT(c, CatStep));
-    catweasel_usleep(c->step_us/2);
+    catweasel_usleep(c->step_us);
 }
 
 static int
@@ -341,7 +340,7 @@ CWTrack0(catweasel_contr *c)
 /* Return true if successful */
 int
 catweasel_init_controller(catweasel_contr *c, int iobase, int mk, char *fwname,
-                          unsigned step_ms, unsigned settle_ms)
+                          unsigned int step_ms, unsigned int settle_ms)
 {
     int i;
     FILE* f = NULL;
@@ -450,7 +449,7 @@ catweasel_init_controller(catweasel_contr *c, int iobase, int mk, char *fwname,
 		fprintf(stderr, "timeout loading MK4 firmware\n");
 		catweasel_free_controller(c);
 		return 0;
-	    }    
+	    }
 	    outb(b, iobase + 0xc0);
 	}
 	if (f) {
@@ -475,7 +474,7 @@ catweasel_init_controller(catweasel_contr *c, int iobase, int mk, char *fwname,
 	    fprintf(stderr, "timeout waiting for MK4 to start\n");
 	    catweasel_free_controller(c);
 	    return 0;
-        }    
+        }
 
 	outb(0x41, iobase + 0x3);
 	break;
@@ -501,7 +500,7 @@ catweasel_detect_drive(catweasel_drive *d)
     if (!c->iobase) {
 	return;
     }
-	
+
     /* select drive and start motor */
     catweasel_select(c, d->number == 0, d->number == 1);
     catweasel_set_motor(d, 1);
@@ -527,12 +526,12 @@ catweasel_detect_drive(catweasel_drive *d)
 	CWTriggerStep(c);
     }
     d->track = 0;
-	
+
     if (j == 90) {
 	/* drive without working track 0 sensor, or no drive */
 	d->type = 0;
     }
-    
+
     /* deselect all drives, stop motor */
     catweasel_set_motor(d, 0);
     catweasel_select(c, 0, 0);
@@ -580,7 +579,7 @@ void
 catweasel_set_motor(catweasel_drive *d, int on)
 {
     int mask = CBIT(d->contr, d->number ? CatMotor1 : CatMotor0);
-    
+
     if (on) {
 	CWSetCReg(d->contr, mask, 0);
     } else {

--- a/catweasl.c
+++ b/catweasl.c
@@ -326,9 +326,9 @@ static void
 CWTriggerStep(catweasel_contr *c)
 {
     CWSetCReg(c, CBIT(c, CatStep), 0);
-    catweasel_usleep(3000);
+    catweasel_usleep(c->step_us/2);
     CWSetCReg(c, 0, CBIT(c, CatStep));
-    catweasel_usleep(3000);
+    catweasel_usleep(c->step_us/2);
 }
 
 static int
@@ -340,7 +340,8 @@ CWTrack0(catweasel_contr *c)
 
 /* Return true if successful */
 int
-catweasel_init_controller(catweasel_contr *c, int iobase, int mk, char *fwname)
+catweasel_init_controller(catweasel_contr *c, int iobase, int mk, char *fwname,
+                          unsigned step_ms, unsigned settle_ms)
 {
     int i;
     FILE* f = NULL;
@@ -350,6 +351,8 @@ catweasel_init_controller(catweasel_contr *c, int iobase, int mk, char *fwname)
 
     c->iobase = iobase;
     c->mk = mk;
+    c->step_us = step_ms * 1000;
+    c->settle_us = settle_ms * 1000;
 
     switch (mk) {
     case 1:
@@ -608,6 +611,9 @@ catweasel_seek(catweasel_drive *d, int t)
 
     while (x--) {
 	CWTriggerStep(d->contr);
+    }
+    if (d->contr->settle_us > 0) {
+	catweasel_usleep(d->contr->settle_us);
     }
 
     d->track = t;

--- a/cw2dmk.c
+++ b/cw2dmk.c
@@ -2254,7 +2254,8 @@ main(int argc, char** argv)
 	int b = 0;
 	int oldb = 0;
 	index_edge = 0;
-	while (!dmk_full || out_level >= OUT_SAMPLES) {
+	while (!dmk_full ||
+               out_level >= OUT_SAMPLES || out_file_level >= OUT_SAMPLES) {
           if (replay) {
             b = parse_sample(replay_file);
           } else {

--- a/cw2dmk.c
+++ b/cw2dmk.c
@@ -134,10 +134,10 @@ int accum_sectors = 0;
 int menu_err_enabled = 0;
 volatile int menu_intr_enabled = 0;
 volatile int menu_requested = 0;
-unsigned step_ms = 6;
-unsigned settle_ms = 0;
+unsigned int step_ms = 6;
+unsigned int settle_ms = 0;
 
-unsigned quirk;
+unsigned int quirk;
 #define QUIRK_ID_CRC     0x01
 #define QUIRK_DATA_CRC   0x02
 #define QUIRK_PREMARK    0x04

--- a/cw2dmk.man
+++ b/cw2dmk.man
@@ -124,7 +124,7 @@ disk.  First capture a logfile at verbosity level 7 using the -v and
 option to replay the logfile, together with other command line options
 as desired.  The -k option is always required with -R, and the -h0
 option generally should be used if the original capture was performed
-with -h0, while the -m, -M, -d, -p, -a, -r, and -x options are not
+with -h0, while the -m, -T, -M, -d, -p, -a, -r, and -x options are not
 allowed.
 .TP
 .B \-M {i,e,d}\fP
@@ -200,6 +200,16 @@ wrong even after having been checked (which can happen only with
 copy-protected disks that are formatted with nonstandard track
 numbers).  The initial guess is 2 if the drive/media type (-k option) is
 set or autodetected to be 1; otherwise the initial guess is 1.
+.TP
+.B \-T \fIstep_time[,settling_time]\fP
+Time in milliseconds to delay after each step pulse (sometimes called
+"step rate"), and additional time to delay after the last step pulse (head
+settling time).  The defaults are 6 ms step time and 0 ms settling time.
+The comma and settling_time value are optional.
+If your drive has difficulty stepping, try a slower step rate.  If you often
+see errors on the first sector or first few sectors of a track, especially
+when reading with -h0, or if you know your drive requires it,
+add some head settling time.
 .TP
 .B \-t \fItracks\fP
 Specifies the number of tracks per side.  If this option is not given,

--- a/cw2dmk.man
+++ b/cw2dmk.man
@@ -206,6 +206,7 @@ Time in milliseconds to delay after each step pulse (sometimes called
 "step rate"), and additional time to delay after the last step pulse (head
 settling time).  The defaults are 6 ms step time and 0 ms settling time.
 The comma and settling_time value are optional.
+
 If your drive has difficulty stepping, try a slower step rate.  If you often
 see errors on the first sector or first few sectors of a track, especially
 when reading with -h0, or if you know your drive requires it,

--- a/cwfloppy.h
+++ b/cwfloppy.h
@@ -24,13 +24,13 @@ typedef struct catweasel_contr {
     unsigned char *ctrl;
     catweasel_drive drives[2];     /* max. two drives on each controller */
     int private[4];                /* private data */
-    unsigned step_us, settle_us;
+    unsigned int step_us, settle_us;
 } catweasel_contr;
 
 /* Initialize a Catweasel controller.  Return true on success. */
 int catweasel_init_controller(catweasel_contr *c, int iobase, int mk,
 			      char *fwname,
-                              unsigned step_ms, unsigned settle_ms);
+                              unsigned int step_ms, unsigned int settle_ms);
 
 /* Detect whether drive is present using track0 sensor */
 void catweasel_detect_drive(catweasel_drive *d);

--- a/cwfloppy.h
+++ b/cwfloppy.h
@@ -24,11 +24,13 @@ typedef struct catweasel_contr {
     unsigned char *ctrl;
     catweasel_drive drives[2];     /* max. two drives on each controller */
     int private[4];                /* private data */
+    unsigned step_us, settle_us;
 } catweasel_contr;
 
 /* Initialize a Catweasel controller.  Return true on success. */
 int catweasel_init_controller(catweasel_contr *c, int iobase, int mk,
-			      char *fwname);
+			      char *fwname,
+                              unsigned step_ms, unsigned settle_ms);
 
 /* Detect whether drive is present using track0 sensor */
 void catweasel_detect_drive(catweasel_drive *d);

--- a/dmk2cw.c
+++ b/dmk2cw.c
@@ -74,6 +74,8 @@ int reverse = 0;
 int datalen = -1;
 double rate_adj = 1.0;
 int dither = 0;
+unsigned step_ms = 6;
+unsigned settle_ms = 0;
 
 void usage()
 {
@@ -92,6 +94,8 @@ void usage()
   printf("               3 = %s\n", kinds[2].description);
   printf("               4 = %s\n", kinds[3].description);
   printf(" -m steps      Step multiplier, 1 or 2 [%d]\n", steps);
+  printf(" -T stp[,stl]  Step time [%u] and head settling time [%u] ms\n",
+         step_ms, settle_ms);
   printf(" -s maxsides   Maximum number of sides, 1 or 2 [%d]\n", maxsides);
   printf("\nThese values normally need not be changed:\n");
   printf(" -p port       I/O port base (MK1) or card number (MK3/4) [%d]\n",
@@ -386,7 +390,7 @@ main(int argc, char** argv)
 
   opterr = 0;
   for (;;) {
-    ch = getopt(argc, argv, "p:d:v:k:m:s:o:c:h:l:g:i:r:f:a:e:y:");
+    ch = getopt(argc, argv, "p:d:v:k:m:s:o:c:h:l:g:i:r:f:a:e:y:T:");
     if (ch == -1) break;
     switch (ch) {
     case 'p':
@@ -467,6 +471,10 @@ main(int argc, char** argv)
       testmode = strtol(optarg, NULL, 0);
       break;
 #endif
+    case 'T':
+      i = sscanf(optarg, "%u,%u", &step_ms, &settle_ms);
+      if (i < 1) usage();
+      break;
     default:
       usage();
       break;
@@ -531,7 +539,8 @@ main(int argc, char** argv)
     exit(1);
   }
 #endif
-  ret = catweasel_init_controller(&c, port, cw_mk, getenv("CW4FIRMWARE"))
+  ret = catweasel_init_controller(&c, port, cw_mk, getenv("CW4FIRMWARE"),
+                                  step_ms, settle_ms)
     && catweasel_memtest(&c);
   if (ret) {
     if (out_fmt >= OUT_QUIET) {

--- a/dmk2cw.man
+++ b/dmk2cw.man
@@ -126,6 +126,7 @@ Time in milliseconds to delay after each step pulse (sometimes called
 "step rate"), and additional time to delay after the last step pulse (head
 settling time).  The defaults are 6 ms step time and 0 ms settling time.
 The comma and settling_time value are optional.
+
 If your drive has difficulty stepping, try a slower step rate.  If you often
 see errors when reading back the first sector or first few sectors
 of a track, or if you know your drive requires it, add some head settling time.

--- a/dmk2cw.man
+++ b/dmk2cw.man
@@ -121,6 +121,15 @@ you set -m2, you should bulk-erase the media first to eliminate
 residual magnetization from the odd numbered tracks that may cause
 problems when the disk is read in a 40-track drive.
 .TP
+.B \-T \fIstep_time[,settling_time]\fP
+Time in milliseconds to delay after each step pulse (sometimes called
+"step rate"), and additional time to delay after the last step pulse (head
+settling time).  The defaults are 6 ms step time and 0 ms settling time.
+The comma and settling_time value are optional.
+If your drive has difficulty stepping, try a slower step rate.  If you often
+see errors when reading back the first sector or first few sectors
+of a track, or if you know your drive requires it, add some head settling time.
+.TP
 .B \-s \fIsides\fP
 Maximum number of sides, 1 or 2.  Use -s1 if your physical floppy drive
 has only one head (that is, if it can only write to side 0 of the disk).

--- a/testhist.c
+++ b/testhist.c
@@ -204,7 +204,8 @@ int main(int argc, char **argv) {
       exit(1);
     }
 #endif
-    ret = catweasel_init_controller(&c, port, cw_mk, getenv("CW4FIRMWARE"))
+    ret = catweasel_init_controller(&c, port, cw_mk, getenv("CW4FIRMWARE"),
+                                    6, 0)
       && catweasel_memtest(&c);
     if (!ret) {
       fprintf(stderr, "testhist: Failed to detect Catweasel at port 0x%x\n", port);


### PR DESCRIPTION
Consider out_file_level too, not just out_level.  Fixes a bug in bb140aab.

I just noticed this bug because the latest dump from Rüdiger was done with -v72 and is missing the samples beyond where the DMK buffer fills up. I had carelessly only tested with -v7, not -v7x for x<7.
