### PR TITLE
Add QUIRK_MFM_CLOCK

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,7 @@
+* Add QUIRK_MFM_CLOCK.  This quirk was needed to read some old UDOS
+  1526 V.3 or V.2 disks, which have clock bits set in certain places
+  that violate the MFM clocking rules.
+
 4.9.2 -- Sun Sep 18 23:11:36 UTC 2022 -- Tim Mann
 
 * Make the -v2 and -v3 output of dmk2cw more readable.

--- a/ChangeLog
+++ b/ChangeLog
@@ -1,6 +1,11 @@
-* Add QUIRK_MFM_CLOCK.  This quirk was needed to read some old UDOS
-  1526 V.3 or V.2 disks, which have clock bits set in certain places
-  that violate the MFM clocking rules.
+* Add QUIRK_MFM_CLOCK.  This quirk was needed to read some older UDOS
+  disks with clock bits set in certain places that violate the MFM
+  clocking rules.  The most frequent violation seen on a sample disk
+  was that in a sequence of bytes with data value ff ff ff..., the
+  clocking pattern could be 00 88 88... instead of 00 00 00...  This
+  results in flux transitions in adjacent bit cells, which is normally
+  illegal in MFM.  The disks were probably from UDOS 1526 V.3, or
+  possibly V.2.
 
 4.9.2 -- Sun Sep 18 23:11:36 UTC 2022 -- Tim Mann
 

--- a/cw2dmk.man
+++ b/cw2dmk.man
@@ -526,6 +526,17 @@ covers the data address mark and all 132 data bytes.
 A standard index address mark (IAM) in FM is the data value 0xfc with
 a 0xd7 clock pattern. If this quirk is specified, cw2dmk recognizes
 0xfc with either a 0xd7 or 0xc7 clock pattern as an IAM.
+.TP
+0x80 (128) QUIRK_MFM_CLOCK
+In general, floppy disk data is encoded as a stream of alternating
+clock and data bit cells.  With MFM encoding, a clock bit cell should
+contain a 1 if and only if the data bit cells immediately before and
+after it both contain 0.  If this quirk is not specified, cw2dmk makes
+a strong assumption that the MFM clocking rule is not violated, and so
+it may fail to decode a disk that has clock bits set to 1 that should
+be 0.  If this quirk is specified, cw2dmk relaxes that assumption and
+may successfully decode such a disk.  It is probably harmless to set
+this quirk even when not needed, but that is mostly untested.
 .RE
 .P
 The next few options modify individual

--- a/dmk.h
+++ b/dmk.h
@@ -56,7 +56,8 @@
 #define QUIRK_EXTRA_CRC  0x10
 #define QUIRK_EXTRA_DATA 0x20
 #define QUIRK_IAM        0x40
-#define QUIRK_ALL        0x7f
+#define QUIRK_MFM_CLOCK  0x80
+#define QUIRK_ALL        0xff
 
 typedef struct {
   uint8_t	writeprot;

--- a/parselog.c
+++ b/parselog.c
@@ -100,7 +100,7 @@ parse_sample(FILE *log_file)
 
   for (;;) {
     // Try to read a sample here.
-    ret = fscanf(log_file, " %d%1[sml]%*[ ]", &sample, &junk[0]);
+    ret = fscanf(log_file, " %d%1[tsml]%*[ ]", &sample, &junk[0]);
     if (ret == EOF) {
       return EOF;
     }

--- a/version.h
+++ b/version.h
@@ -1,1 +1,1 @@
-#define VERSION "4.9.2"
+#define VERSION "4.9.2+"


### PR DESCRIPTION
This quirk was needed to read some old UDOS 1526 V.3 or V.2 disks, which have clock bits set in certain places that violate the MFM clocking rules.