### PR TITLE
Fix indefinite looping while guessing head stepping rate.

### DIFF
--- a/cw2dmk.c
+++ b/cw2dmk.c
@@ -2448,11 +2448,10 @@ main(int argc, char** argv)
 	if (guess_steps) {
 	  if (track == 3) guess_steps = 0;
 	  if (steps == 1) {
-	    if ((track & 1) &&
-		(good_sectors == 0 ||
-		 cylseen == track - 1 || cylseen == track + 1)) {
+	    if ((track & 1) && (good_sectors == 0)) {
 	      msg(OUT_QUIET + 1,
 		  "[double-stepping apparently needed; restarting]\n");
+	      guess_steps = 0;
 	      steps = 2;
 	      if (guess_tracks) tracks = TRACKS_GUESS / steps;
 	      goto restart;


### PR DESCRIPTION
The old stepping code uses the cylinder number from the disk's ID Record to switch stepping rates.  Some disks this information is non-conventional or intentionally wrong which can lead to the old heuristic to make incorrect assumptions flipping the rate back and forth.

The new approach limits still uses the ID record cylinder number, but only when transitioning from step 2 to step 1 breaking the loop.